### PR TITLE
Update Namespace Registry

### DIFF
--- a/namespace-registry-text.md
+++ b/namespace-registry-text.md
@@ -1,0 +1,69 @@
+# OpenC2 Namespace Registry
+
+*Text to be re-written and included in the OpenC2 Architecture*
+
+## Namespace Concepts
+A [namespace](https://en.wikipedia.org/wiki/Namespace) is a set of names used to identify objects.
+A namespace ensures that all of a given set of objects can be easily identified and unambiguously referenced.
+
+All OpenC2 type definitions are contained in a specification, and each specification is assigned a
+globally-unique namespace in the form of a URI.  Types in one specification can reference types
+defined in another specification using a namespaced name:
+
+    name = <namespace identifier> separator <local name>
+
+XML includes namespaces but JSON does not. Because OpenC2 consists of multiple specifications,
+it requires a namespacing mechanism usable with JSON data.
+OpenC2 has therefore created a naming approach similar to XML's that can be applied to non-namespaced
+data formats such as JSON.  For brevity it assigns a short Namespace Identifier (NSID) to each referenced
+namespace using an **import** statement, then uses the NSID as a prefix to each referenced type:
+
+**schema**:
+```
+    import: {"ex": "http://www.example.com/datatypes/v1.2"}
+
+    Person = Record
+        1 name   String
+        2 id     Integer
+        3 email  ex:Email-Address       // type definition imported/resolved from another specification
+```
+**JSON data**:
+```
+    {"name": "John", "id": 12345, "email": "john@acme.com"}
+```
+Namespacing thus involves four different values:
+* **Namespace**: The unique identifier of a referenced specification: "http://www.example.com/datatypes/v1.2"
+* **Type Name**: the name of a type defined in a referenced specification: "Email-Address"
+* **NSID**: a short abbreviation for a Namespace used as a prefix in an imported type: "ex"
+* **Field Name**: may be serialized as a JSON object property whose value is an imported type: "email"
+
+NSID and Field Name are both defined by the importing specification; neither are registered here.
+Type Names (including NSID prefixes) never appear in JSON data, so Namespaces and NSIDs are never
+needed or used in JSON data except within a schema document.
+
+This approach uses a resolver to look up all namespaced type definitions from their defining specifications
+and incorporate them into a single schema. Authors can manually copy and paste definitions
+into a monolithic specification, but namespace resolution automates that process, eliminating redundancy
+and the potential for inconsistency.
+
+A namespace URI is only an identifier. For syntactic reasons it must have a scheme (http) but it
+is not a network-accessible resource. 
+Referenced specifications do not need to be available online and implementations are not required to do
+namespace resolution at runtime, although dynamic namespace resolution may be appropriate for some use cases.
+URLs for online schemas should be derived from the namespace using scheme "https", filename "schema", and
+the applicable file extension: ".jadn" for the abstract schema, and ".json", ".xsd", ".cddl", ".proto", etc.
+for corresponding concrete schemas.
+
+## Registration Process
+OpenC2 TC Documentation Norms suggests
+[naming conventions](https://github.com/oasis-tcs/openc2-tc-ops/blob/master/Documentation-Norms.md#42-assign-work-product-name)
+for TC work products.  Namespace URIs should be based on this convention, omitting the filename and the "docs" domain component,
+and using "http" as the scheme component.
+
+* **Actuator Profile Name**: ap-\<function-shorthand\>
+* **Example Profile URL**: https://docs.oasis-open.org/openc2/ap-av/v1.0/ap-av-v1.0.html
+* **Example Namespace**: http://oasis-open.org/openc2/ap-av/v1.0
+* **Example Schema URL**: https://oasis-open.org/openc2/ap-av/v1.0/schema.jadn
+
+Custom actuator profile namespaces are chosen by the profile author and MUST NOT conflict with namespace URIs registered here.
+Custom profile authors MAY register Namespaces under http://oasis-open.org/openc2/custom but are not required to do so.

--- a/namespace-registry.md
+++ b/namespace-registry.md
@@ -19,8 +19,8 @@ plus functions for profiles under consideration.
 | 1024    | slpf          | [Stateless Packet Filtering AP](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | slpf:     | http://oasis-open.org/openc2/ap-slpf/v1.0     |
 | 1025    | sfpf          | [Stateful Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-sfpf)                       | sfpf:     | http://oasis-open.org/openc2/ap-sfpf/v1.0     |
 | 1026    | sbom          | [Software Bill of Materials AP](https://github.com/oasis-tcs/openc2-ap-sbom)                      | sbom:     | http://oasis-open.org/openc2/ap-sbom/v1.0     |
-| 1027    | er            | [Endpoint Response AP](https://github.com/oasis-tcs/openc2-ap-er)                                 | edr:      | http://oasis-open.org/openc2/ap-edr/v1.0      |
-| 1028    | hop           | [Honeypot Control AP](https://github.com/oasis-tcs/openc2-ap-honeypots)                           | hop:      | http://oasis-open.org/openc2/ap-honeypot/v1.0 |
+| 1027    | er            | [Endpoint Response AP](https://github.com/oasis-tcs/openc2-ap-er)                                 | er:       | http://oasis-open.org/openc2/ap-er/v1.0       |
+| 1028    | hop           | [Honeypot Control AP](https://github.com/oasis-tcs/openc2-ap-honeypots)                           | hop:      | http://oasis-open.org/openc2/ap-hop/v1.0      |
 | 1029    | av            | [Anti-virus AP](https://github.com/oasis-tcs/openc2-ap-av)                                        | av:       | http://oasis-open.org/openc2/ap-av/v1.0       |
 | 1030    | ids           | [Intrusion Detection AP](https://github.com/oasis-tcs/openc2-ap-ids)                              | ids:      | http://oasis-open.org/openc2/ap-ids/v1.0      |
 | 1031    | log           | [Logging Control AP](https://github.com/oasis-tcs/openc2-ap-lc)                                   | log:      | http://oasis-open.org/openc2/ap-log/v1.0      |

--- a/namespace-registry.md
+++ b/namespace-registry.md
@@ -24,7 +24,7 @@ plus functions for profiles under consideration.
 | 1029    | av            | [Anti-virus AP](https://github.com/oasis-tcs/openc2-ap-av)                                        | av:       | http://oasis-open.org/openc2/ap-av/v1.0       |
 | 1030    | ids           | [Intrusion Detection AP](https://github.com/oasis-tcs/openc2-ap-ids)                              | ids:      | http://oasis-open.org/openc2/ap-ids/v1.0      |
 | 1031    | log           | [Logging Control AP](https://github.com/oasis-tcs/openc2-ap-lc)                                   | log:      | http://oasis-open.org/openc2/ap-log/v1.0      |
-| 1032    | sup           | [Software Update AP](https://github.com/oasis-tcs/openc2-ap-sup)                                  |           |                                               |
+| 1032    | sup           | [Software Update AP](https://github.com/oasis-tcs/openc2-ap-sup)                                  | sup:      | http://oasis-open.org/openc2/ap-sup/v1.0      |
 | 1034    | pf            | [Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-pf)                                  | pf:       | http://oasis-open.org/openc2/ap-pf/v1.0       |
 |         |               | <div style="text-align: center">**Custom Actuator Profile**</div>                                 |           |                                               |
 | 9001    | blinky        | Blinky Lights HTTP API                                                                            | led:      | http://oasis-open.org/openc2/custom/haha/v1.0 |

--- a/namespace-registry.md
+++ b/namespace-registry.md
@@ -28,10 +28,13 @@ plus functions for which profiles are under consideration.
 |          |               | <center>**Custom Actuator Profile**</center>                                                      |           |                                               |
 | 9001     | blinky        | Blinky Lights HTTP API                                                                            | led:      | http://oasis-open.org/openc2/custom/haha/v1.0 |
 |          |               | <center>**Proposed Actuator Profile**</center>                                                    |           |                                               |
+|          |               | Endpoint Response (split from EDR)                                                                |           |                                               |
+|          |               | Threat Analytics (split from EDR)                                                                 |           |                                               |
 | ~~1028~~ | ~~sdnc~~      | Software Defined Network Controller                                                               |           |                                               |
 | ~~1029~~ | ~~emgw~~      | Email Gateway                                                                                     |           |                                               |
 | ~~1031~~ | ~~ips~~       | Intrusion Prevention                                                                              |           |                                               |
 | ~~1032~~ | ~~dlp~~       | Data Loss Prevention                                                                              |           |                                               |
 | ~~1033~~ | ~~swg~~       | Secure Web Gateway                                                                                |           |                                               |
 |          |               | Security Posture Attribute Collection                                                             |           |                                               |
+|          |               | Security Posture Evaluation                                                                       |           |                                               |
 |          |               | Cloud Identity and Access Management                                                              |           |                                               |

--- a/namespace-registry.md
+++ b/namespace-registry.md
@@ -2,11 +2,11 @@
 
 The OpenC2 core language is extended using profiles.
 This registry tracks the status of currently defined specifications,
-plus functions for which profiles are under consideration.
+plus functions for profiles under consideration.
 
 * Each specification is assigned a unique identifier (Namespace) in the form of an IRI.
 * A Namespace can be abbreviated using a Namespace Prefix when referencing types defined within it.
-* Properties with namespaced types are identified by a Property ID or Property Name in OpenC2 messages.
+* Properties with namespaced types are identified by ID or Name (depending on serialization) in OpenC2 messages.
 
 | Prop ID  | Property Name | OpenC2 Specification                                                                              | NS Prefix | Namespace                                     |
 |----------|---------------|---------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------|
@@ -19,7 +19,7 @@ plus functions for which profiles are under consideration.
 | 1024     | slpf          | [Stateless Packet Filtering AP](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | slpf:     | http://oasis-open.org/openc2/ap-slpf/v1.0     |
 | 1025     | sfpf          | [Stateful Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-sfpf)                       | sfpf:     | http://oasis-open.org/openc2/ap-sfpf/v1.0     |
 | 1026     | sbom          | [Software Bill of Materials AP](https://github.com/oasis-tcs/openc2-ap-sbom)                      | sbom:     | http://oasis-open.org/openc2/ap-sbom/v1.0     |
-| 1027     | edr           | [Endpoint Detection and Response AP](https://github.com/oasis-tcs/openc2-ap-edr)                  | edr:      | http://oasis-open.org/openc2/ap-edr/v1.0      |
+| 1027     | er            | [Endpoint Response AP](https://github.com/oasis-tcs/openc2-ap-er)                                 | edr:      | http://oasis-open.org/openc2/ap-edr/v1.0      |
 | 1030     | ids           | [Intrusion Detection AP](https://github.com/oasis-tcs/openc2-ap-ids)                              | ids:      | http://oasis-open.org/openc2/ap-ids/v1.0      |
 | 1034     | pf            | [Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-pf)                                  | pf:       | http://oasis-open.org/openc2/ap-pf/v1.0       |
 |          | hop           | [Honeypot Control AP](https://github.com/oasis-tcs/openc2-ap-honeypots)                           | hop:      | http://oasis-open.org/openc2/ap-honeypot/v1.0 |
@@ -28,7 +28,7 @@ plus functions for which profiles are under consideration.
 |          |               | <div style="text-align: center">**Custom Actuator Profile**</div>                                 |           |                                               |
 | 9001     | blinky        | Blinky Lights HTTP API                                                                            | led:      | http://oasis-open.org/openc2/custom/haha/v1.0 |
 |          |               | <div style="text-align: center">**Proposed Actuator Profile**</div>                               |           |                                               |
-|          |               | Endpoint Response (split from EDR)                                                                |           |                                               |
+|          |               | Endpoint Response (previously EDR, listed above)                                                  |           |                                               |
 |          |               | Threat Analytics (split from EDR)                                                                 |           |                                               |
 | ~~1028~~ | ~~sdnc~~      | Software Defined Network Controller                                                               |           |                                               |
 | ~~1029~~ | ~~emgw~~      | Email Gateway                                                                                     |           |                                               |

--- a/namespace-registry.md
+++ b/namespace-registry.md
@@ -1,5 +1,7 @@
 ## OpenC2 Namespace Registry
 
+**Last Update:** 26 January 2022
+
 The OpenC2 core language is extended using profiles.
 This registry tracks the status of currently defined specifications,
 plus functions for profiles under consideration.
@@ -8,34 +10,34 @@ plus functions for profiles under consideration.
 * A Namespace can be abbreviated using a Namespace Prefix when referencing types defined within it.
 * Property sets with namespaced types are identified by ID or Name (depending on serialization) in OpenC2 messages.
 
-| Prop ID | Property Name | OpenC2 Specification                                                                              | NS Prefix | Namespace                                     |
-|---------|---------------|---------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------|
-|         |               | [OpenC2 Language Spec v1.0 CS01](https://github.com/oasis-tcs/openc2-oc2ls)                       |           | http://oasis-open.org/openc2/lang/v1.0        |
-|         |               | [OpenC2 Language Spec v1.0 CS02](https://github.com/oasis-tcs/openc2-oc2ls)                       |           | http://oasis-open.org/openc2/lang/v1.0.1      |
-|         |               | [OpenC2 Language Spec v1.1](https://github.com/oasis-tcs/openc2-oc2ls)                            |           | http://oasis-open.org/openc2/lang/v1.1        |
-|         |               | [OpenC2 Language Spec v1.1 Common Types](https://github.com/oasis-tcs/openc2-oc2ls)               | ls:       | http://oasis-open.org/openc2/types/v1.1       |
-|         |               | [OpenC2 JSON Abstract Data Notation v1.0](https://github.com/oasis-tcs/openc2-jadn)               |           | http://oasis-open.org/openc2/jadn/v1.0        |
-|         |               | <div style="text-align: center">**Standard Actuator Profile**</div>                               |           |                                               |
-| 1024    | slpf          | [Stateless Packet Filtering AP](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | slpf:     | http://oasis-open.org/openc2/ap-slpf/v1.0     |
-| 1025    | sfpf          | [Stateful Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-sfpf)                       | sfpf:     | http://oasis-open.org/openc2/ap-sfpf/v1.0     |
-| 1026    | sbom          | [Software Bill of Materials AP](https://github.com/oasis-tcs/openc2-ap-sbom)                      | sbom:     | http://oasis-open.org/openc2/ap-sbom/v1.0     |
-| 1027    | er            | [Endpoint Response AP](https://github.com/oasis-tcs/openc2-ap-er)                                 | er:       | http://oasis-open.org/openc2/ap-er/v1.0       |
-| 1028    | hop           | [Honeypot Control AP](https://github.com/oasis-tcs/openc2-ap-honeypots)                           | hop:      | http://oasis-open.org/openc2/ap-hop/v1.0      |
-| 1029    | av            | [Anti-virus AP](https://github.com/oasis-tcs/openc2-ap-av)                                        | av:       | http://oasis-open.org/openc2/ap-av/v1.0       |
-| 1030    | ids           | [Intrusion Detection AP](https://github.com/oasis-tcs/openc2-ap-ids)                              | ids:      | http://oasis-open.org/openc2/ap-ids/v1.0      |
-| 1031    | log           | [Logging Control AP](https://github.com/oasis-tcs/openc2-ap-lc)                                   | log:      | http://oasis-open.org/openc2/ap-log/v1.0      |
-| 1032    | sup           | [Software Update AP](https://github.com/oasis-tcs/openc2-ap-sup)                                  | sup:      | http://oasis-open.org/openc2/ap-sup/v1.0      |
-| 1034    | pf            | [Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-pf)                                  | pf:       | http://oasis-open.org/openc2/ap-pf/v1.0       |
-|         |               | <div style="text-align: center">**Custom Actuator Profile**</div>                                 |           |                                               |
-| 9001    | blinky        | Blinky Lights HTTP API                                                                            | led:      | http://oasis-open.org/openc2/custom/haha/v1.0 |
-|         |               | <div style="text-align: center">**Proposed Actuator Profile**</div>                               |           |                                               |
-|         |               | Endpoint Response (previously EDR, listed above)                                                  |           |                                               |
-|         |               | Threat Analytics (split from EDR)                                                                 |           |                                               |
-|         |               | Software Defined Network Controller                                                               |           |                                               |
-|         |               | Email Gateway                                                                                     |           |                                               |
-|         |               | Intrusion Prevention                                                                              |           |                                               |
-|         |               | Data Loss Prevention                                                                              |           |                                               |
-|         |               | Secure Web Gateway                                                                                |           |                                               |
-|         |               | Security Posture Attribute Collection                                                             |           |                                               |
-|         |               | Security Posture Evaluation                                                                       |           |                                               |
-|         |               | Cloud Identity and Access Management                                                              |           |                                               |
+| Prop ID | Property Name | OpenC2 Specification                                                                              | NS Prefix | Namespace                                      | Status                                           |
+|---------|---------------|---------------------------------------------------------------------------------------------------|-----------|------------------------------------------------|--------------------------------------------------|
+|         |               | [OpenC2 Language Spec v1.0 CS01](https://github.com/oasis-tcs/openc2-oc2ls)                       |           | http://oasis-open.org/openc2/lang/v1.0         | CS01 2019/07/11                                  |
+|         |               | [OpenC2 Language Spec v1.0 CS02](https://github.com/oasis-tcs/openc2-oc2ls)                       |           | http://oasis-open.org/openc2/lang/v1.0.1       | CS02 2019/11/04                                  |
+|         |               | [OpenC2 Language Spec v1.1](https://github.com/oasis-tcs/openc2-oc2ls)                            |           | http://oasis-open.org/openc2/lang/v1.1         | CSD01 2021/08/18                                 |
+|         |               | [OpenC2 Language Spec v1.1 Common Types](https://github.com/oasis-tcs/openc2-oc2ls)               | ls:       | http://oasis-open.org/openc2/types/v1.1        | Types section of LS                              |
+|         |               | [OpenC2 JSON Abstract Data Notation v1.0](https://github.com/oasis-tcs/openc2-jadn)               |           | http://oasis-open.org/openc2/jadn/v1.0         | CS01 2021/08/17                                  |
+|         |               | <div style="text-align: center">**Standard Actuator Profile**</div>                               |           |                                                |                                                  |
+| 1024    | slpf          | [Stateless Packet Filtering AP](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | slpf:     | http://oasis-open.org/openc2/ap-slpf/v1.0      | CSPRD01 2019/05/31 superseded by PF              |
+| 1025    | sfpf          | [Stateful Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-sfpf)                       | sfpf:     | http://oasis-open.org/openc2/ap-sfpf/v1.0      | GH WD01, no CSD, superseded by PF                |
+| 1026    | sbom          | [Software Bill of Materials AP](https://github.com/oasis-tcs/openc2-ap-sbom)                      | sbom:     | http://oasis-open.org/openc2/ap-sbom/v1.0      | GH WD01 2021/11/17                               |
+| 1027    | er            | [Endpoint Response AP](https://github.com/oasis-tcs/openc2-ap-er)                                 | er:       | http://oasis-open.org/openc2/ap-er/v1.0        | GH 2021/06/02, rename from EDR                   |
+| 1028    | hop           | [Honeypot Control AP](https://github.com/oasis-tcs/openc2-ap-honeypots)                           | hop:      | http://oasis-open.org/openc2/ap-hop/v1.0       | GH 2021/10/13, use cases                         |
+| 1029    | av            | [Anti-virus AP](https://github.com/oasis-tcs/openc2-ap-av)                                        | av:       | http://oasis-open.org/openc2/ap-av/v1.0        | Repo created                                     |
+| 1030    | ids           | [Intrusion Detection AP](https://github.com/oasis-tcs/openc2-ap-ids)                              | ids:      | http://oasis-open.org/openc2/ap-ids/v1.0       | Repo created, no template                        |
+| 1031    | log           | [Logging Control AP](https://github.com/oasis-tcs/openc2-ap-lc)                                   | log:      | http://oasis-open.org/openc2/ap-log/v1.0       | Repo created, no template                        |
+| 1032    | sup           | [Software Update AP](https://github.com/oasis-tcs/openc2-ap-sup)                                  | sup:      | http://oasis-open.org/openc2/ap-sup/v1.0       | Repo requested                                   |
+| 1034    | pf            | [Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-pf)                                  | pf:       | http://oasis-open.org/openc2/ap-pf/v1.0        | CSD01 2021/07/21 supersedes SLPF and SFPF        |
+|         |               | <div style="text-align: center">**Extension Actuator Profile**</div>                              |           |                                                |                                                  |
+| 9001    | blinky        | Blinky Lights with HTTP and MQTT API                                                              | led:      | http://oasis-open.org/openc2/ext/ap-led/v1.0   | No repo, documented in plugfest use cases        |
+| 9101    | cdiam         | Cloud Identity and Access Management                                                              | cdiam:    | http://oasis-open.org/openc2/ext/ap-cdiam/v1.0 | No repo, planned output of Fall 2021 ACES Course |
+|         |               | <div style="text-align: center">**Proposed Actuator Profile**</div>                               |           |                                                |                                                  |
+|         |               | Endpoint Response (previously EDR, listed above)                                                  |           |                                                |                                                  |
+|         |               | Threat Analytics (split from EDR)                                                                 |           |                                                |                                                  |
+|         |               | Software Defined Network Controller                                                               |           |                                                |                                                  |
+|         |               | Email Gateway                                                                                     |           |                                                |                                                  |
+|         |               | Intrusion Prevention                                                                              |           |                                                |                                                  |
+|         |               | Data Loss Prevention                                                                              |           |                                                |                                                  |
+|         |               | Secure Web Gateway                                                                                |           |                                                |                                                  |
+|         |               | Security Posture Attribute Collection                                                             |           |                                                |                                                  |
+|         |               | Security Posture Evaluation                                                                       |           |                                                |                                                  |

--- a/namespace-registry.md
+++ b/namespace-registry.md
@@ -1,88 +1,37 @@
-# OpenC2 Namespace Registry
-## Namespace Concepts
-A [namespace](https://en.wikipedia.org/wiki/Namespace) is a set of names used to identify objects.
-A namespace ensures that all of a given set of objects can be easily identified and unambiguously referenced.
+## OpenC2 Namespace Registry
 
-All OpenC2 type definitions are contained in a specification, and each specification is assigned a
-globally-unique namespace in the form of a URI.  Types in one specification can reference types
-defined in another specification using a namespaced name:
+The OpenC2 core language is extended using profiles.
+This registry tracks the status of currently defined specifications,
+plus functions for which profiles are under consideration.
 
-    name = <namespace identifier> separator <local name>
+* Each specification is assigned a unique identifier (Namespace) in the form of an IRI.
+* A Namespace can be abbreviated using a Namespace Prefix when referencing types defined within it.
+* Properties with namespaced types are identified by a Property ID or Property Name in OpenC2 messages.
 
-XML includes namespaces but JSON does not. Because OpenC2 consists of multiple specifications,
-it requires a namespacing mechanism usable with JSON data.
-OpenC2 has therefore created a naming approach similar to XML's that can be applied to non-namespaced
-data formats such as JSON.  For brevity it assigns a short Namespace Identifier (NSID) to each referenced
-namespace using an **import** statement, then uses the NSID as a prefix to each referenced type:
-
-**schema**:
-```
-    import: {"ex": "http://www.example.com/datatypes/v1.2"}
-
-    Person = Record
-        1 name   String
-        2 id     Integer
-        3 email  ex:Email-Address       // type definition imported/resolved from another specification
-```
-**JSON data**:
-```
-    {"name": "John", "id": 12345, "email": "john@acme.com"}
-```
-Namespacing thus involves four different values:
-* **Namespace**: The unique identifier of a referenced specification: "http://www.example.com/datatypes/v1.2"
-* **Type Name**: the name of a type defined in a referenced specification: "Email-Address"
-* **NSID**: a short abbreviation for a Namespace used as a prefix in an imported type: "ex"
-* **Field Name**: may be serialized as a JSON object property whose value is an imported type: "email"
-
-NSID and Field Name are both defined by the importing specification; neither are registered here.
-Type Names (including NSID prefixes) never appear in JSON data, so Namespaces and NSIDs are never
-needed or used in JSON data except within a schema document.
-
-This approach uses a resolver to look up all namespaced type definitions from their defining specifications
-and incorporate them into a single schema. Authors can manually copy and paste definitions
-into a monolithic specification, but namespace resolution automates that process, eliminating redundancy
-and the potential for inconsistency.
-
-A namespace URI is only an identifier. For syntactic reasons it must have a scheme (http) but it
-is not a network-accessible resource. 
-Referenced specifications do not need to be available online and implementations are not required to do
-namespace resolution at runtime, although dynamic namespace resolution may be appropriate for some use cases.
-URLs for online schemas should be derived from the namespace using scheme "https", filename "schema", and
-the applicable file extension: ".jadn" for the abstract schema, and ".json", ".xsd", ".cddl", ".proto", etc.
-for corresponding concrete schemas.
-
-## Registration Process
-OpenC2 TC Documentation Norms suggests
-[naming conventions](https://github.com/oasis-tcs/openc2-tc-ops/blob/master/Documentation-Norms.md#42-assign-work-product-name)
-for TC work products.  Namespace URIs should be based on this convention, omitting the filename and the "docs" domain component,
-and using "http" as the scheme component.
-
-* **Actuator Profile Name**: ap-\<function-shorthand\>
-* **Example Profile URL**: https://docs.oasis-open.org/openc2/ap-av/v1.0/ap-av-v1.0.html
-* **Example Namespace**: http://oasis-open.org/openc2/ap-av/v1.0
-* **Example Schema URL**: https://oasis-open.org/openc2/ap-av/v1.0/schema.jadn
-
-Custom actuator profile namespaces are chosen by the profile author and MUST NOT conflict with namespace URIs registered here.
-Custom profile authors MAY register Namespaces under http://oasis-open.org/openc2/custom but are not required to do so.
-
-## Registry
-**Last Update:** 14 July 2020
-| Specification | Namespace | Source |
-| ------------- | --------- | ------ |
-| OpenC2 Language Spec v1.0 CS01    | http://oasis-open.org/openc2/lang/v1.0        | https://github.com/oasis-tcs/openc2-oc2ls |
-| OpenC2 Language Spec v1.0 CS02    | http://oasis-open.org/openc2/lang/v1.0.1      | https://github.com/oasis-tcs/openc2-oc2ls |
-| OpenC2 Language Profile v1.1      | http://oasis-open.org/openc2/lang/v1.1        | Language SC - Work in progress |
-| OpenC2 Common Types v1.1          | http://oasis-open.org/openc2/types/v1.1       | Language SC - Work in progress |
-| Stateless Packet Filtering AP     | http://oasis-open.org/openc2/ap-slpf/v1.0     | https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter |
-| Stateful Packet Filtering AP      | http://oasis-open.org/openc2/ap-sfpf/v1.0     | https://github.com/oasis-tcs/openc2-ap-sfpf |
-| Software Bill of Materials AP     | http://oasis-open.org/openc2/ap-sbom/v1.0     | https://github.com/oasis-tcs/openc2-ap-sbom |
-| Intrusion Detection AP            | http://oasis-open.org/openc2/ap-ids/v1.0      | https://github.com/oasis-tcs/openc2-ap-ids Repo Exists |
-| Honeypot functions AP             | http://oasis-open.org/openc2/ap-honeypot/v1.0 | https://github.com/oasis-tcs/openc2-ap-honeypots Repo Exists |
-| Endpoint functions AP             |                                               | Proposed for LS |
-| Software-Defined Nework Control AP|                                               | Proposed for LS |
-| Email Gateway functions AP        |                                               | Proposed for LS |
-| Intrusion Prevention AP           |                                               | Proposed for LS |
-| Data Loss Prevention AP           |                                               | Proposed for LS |
-| Secure Web Gateway AP             |                                               | Proposed for LS |
-| Hello-world API HTTP CAP          | http://oasis-open.org/openc2/custom/haha/v1.0 | Example: Custom AP namespaces may be registered |
-| Hello-world API MQTT CAP          | http://acme.com/openc2-profiles/hama/v1.0     | Example: Custom AP namespaces are chosen by their authors |
+| Prop ID  | Property Name | OpenC2 Specification                                                                              | NS Prefix | Namespace                                     |
+|----------|---------------|---------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------|
+|          |               | [OpenC2 Language Spec v1.0 CS01](https://github.com/oasis-tcs/openc2-oc2ls)                       |           | http://oasis-open.org/openc2/lang/v1.0        |
+|          |               | [OpenC2 Language Spec v1.0 CS02](https://github.com/oasis-tcs/openc2-oc2ls)                       |           | http://oasis-open.org/openc2/lang/v1.0.1      |
+|          |               | [OpenC2 Language Spec v1.1](https://github.com/oasis-tcs/openc2-oc2ls)                            |           | http://oasis-open.org/openc2/lang/v1.1        |
+|          |               | [OpenC2 Language Spec v1.1 Common Types](https://github.com/oasis-tcs/openc2-oc2ls)               | ls:       | http://oasis-open.org/openc2/types/v1.1       |
+|          |               | [OpenC2 JSON Abstract Data Notation v1.0](https://github.com/oasis-tcs/openc2-jadn)               |           | http://oasis-open.org/openc2/jadn/v1.0        |
+|          |               | <center>**Standard Actuator Profile**</center>                                                    |           |                                               |
+| 1024     | slpf          | [Stateless Packet Filtering AP](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | slpf:     | http://oasis-open.org/openc2/ap-slpf/v1.0     |
+| 1025     | sfpf          | [Stateful Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-sfpf)                       | sfpf:     | http://oasis-open.org/openc2/ap-sfpf/v1.0     |
+| 1026     | sbom          | [Software Bill of Materials AP](https://github.com/oasis-tcs/openc2-ap-sbom)                      | sbom:     | http://oasis-open.org/openc2/ap-sbom/v1.0     |
+| 1027     | edr           | [Endpoint Detection and Response AP](https://github.com/oasis-tcs/openc2-ap-edr)                  | edr:      | http://oasis-open.org/openc2/ap-edr/v1.0      |
+| 1030     | ids           | [Intrusion Detection AP](https://github.com/oasis-tcs/openc2-ap-ids)                              | ids:      | http://oasis-open.org/openc2/ap-ids/v1.0      |
+| 1034     | pf            | [Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-pf)                                  | pf:       | http://oasis-open.org/openc2/ap-pf/v1.0       |
+|          | hop           | [Honeypot Control AP](https://github.com/oasis-tcs/openc2-ap-honeypots)                           | hop:      | http://oasis-open.org/openc2/ap-honeypot/v1.0 |
+|          | av            | [Anti-virus AP](https://github.com/oasis-tcs/openc2-ap-av)                                        | av:       | http://oasis-open.org/openc2/ap-av/v1.0       |
+|          | log           | [Logging Control AP](https://github.com/oasis-tcs/openc2-ap-lc)                                   | log:      | http://oasis-open.org/openc2/ap-log/v1.0      |
+|          |               | <center>**Custom Actuator Profile**</center>                                                      |           |                                               |
+| 9001     | blinky        | Blinky Lights HTTP API                                                                            | led:      | http://oasis-open.org/openc2/custom/haha/v1.0 |
+|          |               | <center>**Proposed Actuator Profile**</center>                                                    |           |                                               |
+| ~~1028~~ | ~~sdnc~~      | Software Defined Network Controller                                                               |           |                                               |
+| ~~1029~~ | ~~emgw~~      | Email Gateway                                                                                     |           |                                               |
+| ~~1031~~ | ~~ips~~       | Intrusion Prevention                                                                              |           |                                               |
+| ~~1032~~ | ~~dlp~~       | Data Loss Prevention                                                                              |           |                                               |
+| ~~1033~~ | ~~swg~~       | Secure Web Gateway                                                                                |           |                                               |
+|          |               | Security Posture Attribute Collection                                                             |           |                                               |
+|          |               | Cloud Identity and Access Management                                                              |           |                                               |

--- a/namespace-registry.md
+++ b/namespace-registry.md
@@ -6,7 +6,7 @@ plus functions for profiles under consideration.
 
 * Each specification is assigned a unique identifier (Namespace) in the form of an IRI.
 * A Namespace can be abbreviated using a Namespace Prefix when referencing types defined within it.
-* Properties with namespaced types are identified by ID or Name (depending on serialization) in OpenC2 messages.
+* Property sets with namespaced types are identified by ID or Name (depending on serialization) in OpenC2 messages.
 
 | Prop ID  | Property Name | OpenC2 Specification                                                                              | NS Prefix | Namespace                                     |
 |----------|---------------|---------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------|

--- a/namespace-registry.md
+++ b/namespace-registry.md
@@ -8,33 +8,34 @@ plus functions for profiles under consideration.
 * A Namespace can be abbreviated using a Namespace Prefix when referencing types defined within it.
 * Property sets with namespaced types are identified by ID or Name (depending on serialization) in OpenC2 messages.
 
-| Prop ID  | Property Name | OpenC2 Specification                                                                              | NS Prefix | Namespace                                     |
-|----------|---------------|---------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------|
-|          |               | [OpenC2 Language Spec v1.0 CS01](https://github.com/oasis-tcs/openc2-oc2ls)                       |           | http://oasis-open.org/openc2/lang/v1.0        |
-|          |               | [OpenC2 Language Spec v1.0 CS02](https://github.com/oasis-tcs/openc2-oc2ls)                       |           | http://oasis-open.org/openc2/lang/v1.0.1      |
-|          |               | [OpenC2 Language Spec v1.1](https://github.com/oasis-tcs/openc2-oc2ls)                            |           | http://oasis-open.org/openc2/lang/v1.1        |
-|          |               | [OpenC2 Language Spec v1.1 Common Types](https://github.com/oasis-tcs/openc2-oc2ls)               | ls:       | http://oasis-open.org/openc2/types/v1.1       |
-|          |               | [OpenC2 JSON Abstract Data Notation v1.0](https://github.com/oasis-tcs/openc2-jadn)               |           | http://oasis-open.org/openc2/jadn/v1.0        |
-|          |               | <div style="text-align: center">**Standard Actuator Profile**</div>                               |           |                                               |
-| 1024     | slpf          | [Stateless Packet Filtering AP](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | slpf:     | http://oasis-open.org/openc2/ap-slpf/v1.0     |
-| 1025     | sfpf          | [Stateful Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-sfpf)                       | sfpf:     | http://oasis-open.org/openc2/ap-sfpf/v1.0     |
-| 1026     | sbom          | [Software Bill of Materials AP](https://github.com/oasis-tcs/openc2-ap-sbom)                      | sbom:     | http://oasis-open.org/openc2/ap-sbom/v1.0     |
-| 1027     | er            | [Endpoint Response AP](https://github.com/oasis-tcs/openc2-ap-er)                                 | edr:      | http://oasis-open.org/openc2/ap-edr/v1.0      |
-| 1030     | ids           | [Intrusion Detection AP](https://github.com/oasis-tcs/openc2-ap-ids)                              | ids:      | http://oasis-open.org/openc2/ap-ids/v1.0      |
-| 1034     | pf            | [Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-pf)                                  | pf:       | http://oasis-open.org/openc2/ap-pf/v1.0       |
-|          | hop           | [Honeypot Control AP](https://github.com/oasis-tcs/openc2-ap-honeypots)                           | hop:      | http://oasis-open.org/openc2/ap-honeypot/v1.0 |
-|          | av            | [Anti-virus AP](https://github.com/oasis-tcs/openc2-ap-av)                                        | av:       | http://oasis-open.org/openc2/ap-av/v1.0       |
-|          | log           | [Logging Control AP](https://github.com/oasis-tcs/openc2-ap-lc)                                   | log:      | http://oasis-open.org/openc2/ap-log/v1.0      |
-|          |               | <div style="text-align: center">**Custom Actuator Profile**</div>                                 |           |                                               |
-| 9001     | blinky        | Blinky Lights HTTP API                                                                            | led:      | http://oasis-open.org/openc2/custom/haha/v1.0 |
-|          |               | <div style="text-align: center">**Proposed Actuator Profile**</div>                               |           |                                               |
-|          |               | Endpoint Response (previously EDR, listed above)                                                  |           |                                               |
-|          |               | Threat Analytics (split from EDR)                                                                 |           |                                               |
-| ~~1028~~ | ~~sdnc~~      | Software Defined Network Controller                                                               |           |                                               |
-| ~~1029~~ | ~~emgw~~      | Email Gateway                                                                                     |           |                                               |
-| ~~1031~~ | ~~ips~~       | Intrusion Prevention                                                                              |           |                                               |
-| ~~1032~~ | ~~dlp~~       | Data Loss Prevention                                                                              |           |                                               |
-| ~~1033~~ | ~~swg~~       | Secure Web Gateway                                                                                |           |                                               |
-|          |               | Security Posture Attribute Collection                                                             |           |                                               |
-|          |               | Security Posture Evaluation                                                                       |           |                                               |
-|          |               | Cloud Identity and Access Management                                                              |           |                                               |
+| Prop ID | Property Name | OpenC2 Specification                                                                              | NS Prefix | Namespace                                     |
+|---------|---------------|---------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------|
+|         |               | [OpenC2 Language Spec v1.0 CS01](https://github.com/oasis-tcs/openc2-oc2ls)                       |           | http://oasis-open.org/openc2/lang/v1.0        |
+|         |               | [OpenC2 Language Spec v1.0 CS02](https://github.com/oasis-tcs/openc2-oc2ls)                       |           | http://oasis-open.org/openc2/lang/v1.0.1      |
+|         |               | [OpenC2 Language Spec v1.1](https://github.com/oasis-tcs/openc2-oc2ls)                            |           | http://oasis-open.org/openc2/lang/v1.1        |
+|         |               | [OpenC2 Language Spec v1.1 Common Types](https://github.com/oasis-tcs/openc2-oc2ls)               | ls:       | http://oasis-open.org/openc2/types/v1.1       |
+|         |               | [OpenC2 JSON Abstract Data Notation v1.0](https://github.com/oasis-tcs/openc2-jadn)               |           | http://oasis-open.org/openc2/jadn/v1.0        |
+|         |               | <div style="text-align: center">**Standard Actuator Profile**</div>                               |           |                                               |
+| 1024    | slpf          | [Stateless Packet Filtering AP](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | slpf:     | http://oasis-open.org/openc2/ap-slpf/v1.0     |
+| 1025    | sfpf          | [Stateful Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-sfpf)                       | sfpf:     | http://oasis-open.org/openc2/ap-sfpf/v1.0     |
+| 1026    | sbom          | [Software Bill of Materials AP](https://github.com/oasis-tcs/openc2-ap-sbom)                      | sbom:     | http://oasis-open.org/openc2/ap-sbom/v1.0     |
+| 1027    | er            | [Endpoint Response AP](https://github.com/oasis-tcs/openc2-ap-er)                                 | edr:      | http://oasis-open.org/openc2/ap-edr/v1.0      |
+| 1028    | hop           | [Honeypot Control AP](https://github.com/oasis-tcs/openc2-ap-honeypots)                           | hop:      | http://oasis-open.org/openc2/ap-honeypot/v1.0 |
+| 1029    | av            | [Anti-virus AP](https://github.com/oasis-tcs/openc2-ap-av)                                        | av:       | http://oasis-open.org/openc2/ap-av/v1.0       |
+| 1030    | ids           | [Intrusion Detection AP](https://github.com/oasis-tcs/openc2-ap-ids)                              | ids:      | http://oasis-open.org/openc2/ap-ids/v1.0      |
+| 1031    | log           | [Logging Control AP](https://github.com/oasis-tcs/openc2-ap-lc)                                   | log:      | http://oasis-open.org/openc2/ap-log/v1.0      |
+| 1032    | sup           | [Software Update AP](https://github.com/oasis-tcs/openc2-ap-sup)                                  |           |                                               |
+| 1034    | pf            | [Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-pf)                                  | pf:       | http://oasis-open.org/openc2/ap-pf/v1.0       |
+|         |               | <div style="text-align: center">**Custom Actuator Profile**</div>                                 |           |                                               |
+| 9001    | blinky        | Blinky Lights HTTP API                                                                            | led:      | http://oasis-open.org/openc2/custom/haha/v1.0 |
+|         |               | <div style="text-align: center">**Proposed Actuator Profile**</div>                               |           |                                               |
+|         |               | Endpoint Response (previously EDR, listed above)                                                  |           |                                               |
+|         |               | Threat Analytics (split from EDR)                                                                 |           |                                               |
+|         |               | Software Defined Network Controller                                                               |           |                                               |
+|         |               | Email Gateway                                                                                     |           |                                               |
+|         |               | Intrusion Prevention                                                                              |           |                                               |
+|         |               | Data Loss Prevention                                                                              |           |                                               |
+|         |               | Secure Web Gateway                                                                                |           |                                               |
+|         |               | Security Posture Attribute Collection                                                             |           |                                               |
+|         |               | Security Posture Evaluation                                                                       |           |                                               |
+|         |               | Cloud Identity and Access Management                                                              |           |                                               |

--- a/namespace-registry.md
+++ b/namespace-registry.md
@@ -15,7 +15,7 @@ plus functions for which profiles are under consideration.
 |          |               | [OpenC2 Language Spec v1.1](https://github.com/oasis-tcs/openc2-oc2ls)                            |           | http://oasis-open.org/openc2/lang/v1.1        |
 |          |               | [OpenC2 Language Spec v1.1 Common Types](https://github.com/oasis-tcs/openc2-oc2ls)               | ls:       | http://oasis-open.org/openc2/types/v1.1       |
 |          |               | [OpenC2 JSON Abstract Data Notation v1.0](https://github.com/oasis-tcs/openc2-jadn)               |           | http://oasis-open.org/openc2/jadn/v1.0        |
-|          |               | <center>**Standard Actuator Profile**</center>                                                    |           |                                               |
+|          |               | <div style="text-align: center">**Standard Actuator Profile**</div>                               |           |                                               |
 | 1024     | slpf          | [Stateless Packet Filtering AP](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | slpf:     | http://oasis-open.org/openc2/ap-slpf/v1.0     |
 | 1025     | sfpf          | [Stateful Packet Filtering AP](https://github.com/oasis-tcs/openc2-ap-sfpf)                       | sfpf:     | http://oasis-open.org/openc2/ap-sfpf/v1.0     |
 | 1026     | sbom          | [Software Bill of Materials AP](https://github.com/oasis-tcs/openc2-ap-sbom)                      | sbom:     | http://oasis-open.org/openc2/ap-sbom/v1.0     |
@@ -25,9 +25,9 @@ plus functions for which profiles are under consideration.
 |          | hop           | [Honeypot Control AP](https://github.com/oasis-tcs/openc2-ap-honeypots)                           | hop:      | http://oasis-open.org/openc2/ap-honeypot/v1.0 |
 |          | av            | [Anti-virus AP](https://github.com/oasis-tcs/openc2-ap-av)                                        | av:       | http://oasis-open.org/openc2/ap-av/v1.0       |
 |          | log           | [Logging Control AP](https://github.com/oasis-tcs/openc2-ap-lc)                                   | log:      | http://oasis-open.org/openc2/ap-log/v1.0      |
-|          |               | <center>**Custom Actuator Profile**</center>                                                      |           |                                               |
+|          |               | <div style="text-align: center">**Custom Actuator Profile**</div>                                 |           |                                               |
 | 9001     | blinky        | Blinky Lights HTTP API                                                                            | led:      | http://oasis-open.org/openc2/custom/haha/v1.0 |
-|          |               | <center>**Proposed Actuator Profile**</center>                                                    |           |                                               |
+|          |               | <div style="text-align: center">**Proposed Actuator Profile**</div>                               |           |                                               |
 |          |               | Endpoint Response (split from EDR)                                                                |           |                                               |
 |          |               | Threat Analytics (split from EDR)                                                                 |           |                                               |
 | ~~1028~~ | ~~sdnc~~      | Software Defined Network Controller                                                               |           |                                               |

--- a/namespace-registry.md
+++ b/namespace-registry.md
@@ -8,7 +8,7 @@ plus functions for profiles under consideration.
 
 * Each specification is assigned a unique identifier (Namespace) in the form of an IRI.
 * A Namespace can be abbreviated using a Namespace Prefix when referencing types defined within it.
-* Property sets with namespaced types are identified by ID or Name (depending on serialization) in OpenC2 messages.
+* Namespaced property sets (e.g., Targets, Args, Results) are identified by ID or Name, depending on serialization, in OpenC2 messages.
 
 | Prop ID | Property Name | OpenC2 Specification                                                                              | NS Prefix | Namespace                                      | Status                                           |
 |---------|---------------|---------------------------------------------------------------------------------------------------|-----------|------------------------------------------------|--------------------------------------------------|


### PR DESCRIPTION
This PR updates the namespace registry file to include property IDs/Names from the Language Spec.  It removes property IDs/Names for profiles that do not exist, leaving a description in the Proposed Profiles section.

It removes most descriptive text from the registry document, preserving it in a temporary file until a replacement description is incorporated in the Architecture document.

Because of the restructuring the difference view may be less than helpful.  The registry can be viewed at https://github.com/davaya/openc2-oc2arch/blob/working/namespace-registry.md.