### PR TITLE
Section 2 updates

### DIFF
--- a/oc2arch-v1.0.md
+++ b/oc2arch-v1.0.md
@@ -508,7 +508,7 @@ configuration 3 there is no assumption that the interface
 between the Consumer manager and the managed devices uses
 OpenC2 Commands and Responses.
 
-**Figure 2-2. Producer / Consumer / Device COnfigurations**
+**Figure 2-2. Producer / Consumer / Device Configurations**
 
 ![Producer-Consumer-Device Configurations](images/PCD-Configurations.png)
 

--- a/oc2arch-v1.0.md
+++ b/oc2arch-v1.0.md
@@ -378,10 +378,11 @@ OpenC2 is a suite of specifications for Producers and Consumers
 to command and execute cyber defense functions. These
 specifications include the OpenC2 Language Specification,
 Actuator Profiles, and Transfer Specifications. The OpenC2
-Language Specification and Actuator Profile specifications focus
-on the language content and meaning at the Producer and Consumer
-of the Command and Response while the transfer specifications
-focus on the protocols for their exchange.
+[Language Specification](#openc2-lang-v10) and Actuator Profile
+specifications focus on the language content and meaning at the
+Producer and Consumer level of Command and Response while the
+transfer specifications focus on the protocols for their
+exchange.
 
 In general, there are two types of participants involved in the
 exchange of OpenC2 Messages, as depicted in Figure 2-1:
@@ -408,31 +409,6 @@ The language defines two payload structures:
 2. **Response**: Any information sent back to the Producer as a
    result of the Command.
 
-The Action and Target components are required. A particular
-Target may be further refined by the Target type. The [Language
-Specification](#openc2-lang-v10) defines procedures to extend the
-set of OpenC2 Targets.
-
-Command Arguments, if present, influence the Command by providing
-information such as timing, periodicity, duration, or other
-details on what is to be executed. Command Arguments are defined
-in the OpenC2 Language Specification.
-
-An Actuator is an implementation of a cyber defense function that
-executes the Command. An Actuator Profile is a specification that
-identifies the subset of Actions, Targets and other aspects of
-this language specification that are required or optional in the
-context of a particular Actuator. An Actuator Profile may extend
-the language by defining additional Targets, Arguments, and
-Actuator Specifiers that are meaningful and possibly unique to
-the Actuator.
-
-The Actuator may be omitted from a Command and typically will not
-be included in implementations where the identities of the
-endpoints are unambiguous or when a high-level effects-based
-Command is desired and the tactical decisions on how the effect
-is achieved is left to the recipient.
-
 ## 2.1 Commands and Responses
 
 The OpenC2 language has two distinct content types: Command and
@@ -441,8 +417,6 @@ describes an Action to be performed by an Actuator on a Target.
 The Response is sent from a Consumer, usually back to the
 Producer, and is a means to provide information (such as
 acknowledgment, status, etc.) as a result of a Command.
-
-
 
 ### 2.1.1 OpenC2 Command
 The Command describes an Action to be performed on a Target and
@@ -474,6 +448,11 @@ Command.
   precision, such as a specific Actuator, a list of Actuators, or
   a group of Actuators.
 
+The Action and Target components are required. A particular
+Target may be further refined by the Target type. The [Language
+Specification](#openc2-lang-v10) defines procedures to extend the
+set of OpenC2 Targets.
+
 Command Arguments, if present, influence the Command by providing
 information such as timing, periodicity, duration, or other
 details on what is to be executed. They can also be used to
@@ -483,7 +462,7 @@ information about the execution of a Command.
 An Actuator is an implementation of a cyber defense function that
 executes the Command. An Actuator Profile is a specification that
 identifies the subset of Actions, Targets and other aspects of
-this language specification that are required or optional in the
+the OpenC2 language that are required or optional in the
 context of a particular Actuator. An Actuator Profile may extend
 the language by defining additional Targets, Arguments, and
 Actuator Specifiers that are meaningful and possibly unique to
@@ -494,6 +473,7 @@ be included in implementations where the identities of the
 endpoints are unambiguous or when a high-level effects-based
 Command is desired and the tactical decisions on how the effect
 is achieved is left to the recipient.
+
 
 ### 2.1.2 OpenC2 Response
 The Response is a Message sent from the recipient of a Command.

--- a/oc2arch-v1.0.md
+++ b/oc2arch-v1.0.md
@@ -421,15 +421,9 @@ acknowledgment, status, etc.) as a result of a Command.
 ### 2.1.1 OpenC2 Command
 The Command describes an Action to be performed on a Target and
 may include information identifying the Actuator or Actuators
-that are to execute the Command.
-
-A Command has four main components, two required and two
-optional. The required components are the Action and the Target.
-The optional components are Command Arguments and the Actuator. A
-Command can also contain an optional Command identifier, if
-necessary.
-
-The following list summarizes the main four components of a
+that are to execute the Command. A Command can also contain an
+optional Command identifier, if necessary. The following list
+summarizes the main four components of a
 Command.
 
 * **Action** (required): The task or activity to be performed.

--- a/oc2arch-v1.0.md
+++ b/oc2arch-v1.0.md
@@ -384,7 +384,7 @@ of the Command and Response while the transfer specifications
 focus on the protocols for their exchange.
 
 In general, there are two types of participants involved in the
-exchange of OpenC2 Messages, as depicted in Figure 1-1:
+exchange of OpenC2 Messages, as depicted in Figure 2-1:
 
 1. **Producers**: A Producer is an entity that creates Commands
    to provide instruction to one or more systems to act in
@@ -394,6 +394,11 @@ exchange of OpenC2 Messages, as depicted in Figure 1-1:
    act upon a Command. A Consumer may create Responses that
    provide any information captured or necessary to send back to
    the Producer.
+
+**Figure 2-1. OpenC2 Message Exchange**
+
+![OpenC2 Message Exchange](images/MessageFlow.png)
+
 
 The language defines two payload structures:
 
@@ -437,9 +442,6 @@ The Response is sent from a Consumer, usually back to the
 Producer, and is a means to provide information (such as
 acknowledgment, status, etc.) as a result of a Command.
 
-**Figure 2-1. OpenC2 Message Exchange**
-
-![OpenC2 Message Exchange](images/MessageFlow.png)
 
 
 ### 2.1.1 OpenC2 Command

--- a/oc2arch-v1.0.md
+++ b/oc2arch-v1.0.md
@@ -404,9 +404,9 @@ The language defines two payload structures:
    result of the Command.
 
 The Action and Target components are required. A particular
-Target may be further refined by the Target type. Procedures to
-extend the Targets are described in [Section
-3.1.4](#314-extensions).
+Target may be further refined by the Target type. The [Language
+Specification](#openc2-lang-v10) defines procedures to extend the
+set of OpenC2 Targets.
 
 Command Arguments, if present, influence the Command by providing
 information such as timing, periodicity, duration, or other
@@ -451,8 +451,7 @@ A Command has four main components, two required and two
 optional. The required components are the Action and the Target.
 The optional components are Command Arguments and the Actuator. A
 Command can also contain an optional Command identifier, if
-necessary. [Section 3.3.1](#331-openc2-command) defines the
-syntax of an OpenC2 Command.
+necessary.
 
 The following list summarizes the main four components of a
 Command.
@@ -473,21 +472,11 @@ Command.
   precision, such as a specific Actuator, a list of Actuators, or
   a group of Actuators.
 
-The Action and Target components are required and are populated
-by one of the Actions in [Section 3.3.1.1](#3311-action) and the
-Targets in [Section 3.3.1.2](#3312-target). A particular Target
-may be further refined by the Target type definitions in [Section
-3.4.1](#341-target-types). Procedures to extend the Targets are
-described in [Section 3.1.4](#314-extensions).
-
 Command Arguments, if present, influence the Command by providing
 information such as timing, periodicity, duration, or other
 details on what is to be executed. They can also be used to
 convey the need for acknowledgment or additional status
-information about the execution of a Command. The valid Arguments
-defined in this specification are in [Section
-3.3.1.4](#3314-command-arguments). Procedures to extend Arguments
-are described in [Section 3.1.4](#314-extensions).
+information about the execution of a Command.
 
 An Actuator is an implementation of a cyber defense function that
 executes the Command. An Actuator Profile is a specification that
@@ -511,8 +500,7 @@ query, or other information. At a minimum, a Response will
 contain a status code to indicate the result of performing the
 Command. Additional status text and response fields optionally
 provide more detailed information that is specific to or
-requested by the Command. [Section 3.3.2](#332-openc2-response)
-defines the syntax of an OpenC2 Response.
+requested by the Command.
 
 
 ## 2.2 Producers, Consumers, and Devices
@@ -574,9 +562,9 @@ Table 2-1.
 
 | Layer | Examples |
 | :--- | :--- |
-| Function-Specific Content | Actuator Profiles<br>([[OpenC2-SLPF-v1.0]](#openc2-slpf-v10), ...) |
+| Function-Specific Content | Actuator Profiles<br>([OpenC2-SLPF-v1.0](#openc2-slpf-v10), ...) |
 | Common Content | Language Specification<br>(this document) |
-| Message | Transfer Specifications<br>([[OpenC2-HTTPS-v1.0]](#openc2-https-v10), OpenC2-over-CoAP, ...) |
+| Message | Transfer Specifications<br>([OpenC2-HTTPS-v1.0](#openc2-https-v10), [OpenC2-MQTT-v1.0](#openc2-mqtt-v10), ...) |
 | Secure Transport | HTTPS, CoAP, MQTT, OpenDXL, ... |
 
 * The **Secure Transport** layer provides a communication path

--- a/oc2arch-v1.0.md
+++ b/oc2arch-v1.0.md
@@ -515,17 +515,16 @@ OpenC2 Commands and Responses.
 
 ## 2.3 Implementations
 
-OpenC2 implementations integrate the related OpenC2
-specifications described above with related industry
-specifications, protocols, and standards. Figure 2-3 depicts the
-relationships among OpenC2 specifications, and their
-relationships to other industry standards and
-environment-specific implementations of OpenC2. Note that the
-layering of implementation aspects in the diagram is notional,
-and not intended to preclude any particular approach to
-implementing the needed functionality (for example, the use of an
-application-layer message signature function to provide message
-source authentication and integrity).
+OpenC2 implementations integrate the OpenC2 specifications
+described above with related industry specifications, protocols,
+and standards. Figure 2-3 depicts the relationships among the
+family of OpenC2 specifications, and their relationships to other
+industry standards and environment-specific implementations of
+OpenC2. Note that the layering of implementation aspects in the
+diagram is notional, and not intended to preclude any particular
+approach to implementing the needed functionality (for example,
+the use of an application-layer message signature function to
+provide message source authentication and integrity).
 
 
 **Figure 2-3. OpenC2 Documentation and Layering Model**
@@ -539,7 +538,7 @@ Table 2-1.
 | Layer | Examples |
 | :--- | :--- |
 | Function-Specific Content | Actuator Profiles<br>([OpenC2-SLPF-v1.0](#openc2-slpf-v10), ...) |
-| Common Content | Language Specification<br>(this document) |
+| Common Content | Language Specification |
 | Message | Transfer Specifications<br>([OpenC2-HTTPS-v1.0](#openc2-https-v10), [OpenC2-MQTT-v1.0](#openc2-mqtt-v10), ...) |
 | Secure Transport | HTTPS, CoAP, MQTT, OpenDXL, ... |
 

--- a/oc2arch-v1.0.md
+++ b/oc2arch-v1.0.md
@@ -517,7 +517,7 @@ OpenC2 Commands and Responses.
 
 OpenC2 implementations integrate the related OpenC2
 specifications described above with related industry
-specifications, protocols, and standards. Figure 1-2 depicts the
+specifications, protocols, and standards. Figure 2-3 depicts the
 relationships among OpenC2 specifications, and their
 relationships to other industry standards and
 environment-specific implementations of OpenC2. Note that the
@@ -528,7 +528,7 @@ application-layer message signature function to provide message
 source authentication and integrity).
 
 
-**Figure 2-2. OpenC2 Documentation and Layering Model**
+**Figure 2-3. OpenC2 Documentation and Layering Model**
 ![OpenC2 Documentation and Layering Model](images/OC2LayeringModel.png)
 
 OpenC2 is conceptually partitioned into four layers as shown in


### PR DESCRIPTION
Miscellaneous fixes to section 2 to create a cleaner starting point for further improvement.

- eliminate inappropriate internal references to language spec sections
- smooth organization of existing content and remove duplication