### PR TITLE
Add Goal text

### DIFF
--- a/namespace-registry-text.md
+++ b/namespace-registry-text.md
@@ -3,20 +3,26 @@
 *Text to be re-written and included in the OpenC2 Architecture*
 
 ## Namespace Concepts
-A [namespace](https://en.wikipedia.org/wiki/Namespace) is a set of names used to identify objects.
-A namespace ensures that all of a given set of objects can be easily identified and unambiguously referenced.
+A [namespace](https://en.wikipedia.org/wiki/Namespace) is a set
+of names used to identify objects. A namespace ensures that all
+of a given set of objects can be easily identified and
+unambiguously referenced.
 
-All OpenC2 type definitions are contained in a specification, and each specification is assigned a
-globally-unique namespace in the form of a URI.  Types in one specification can reference types
+All OpenC2 type definitions are contained in a specification, and
+each specification is assigned a globally-unique namespace in the
+form of a URI.  Types in one specification can reference types
 defined in another specification using a namespaced name:
 
     name = <namespace identifier> separator <local name>
 
-XML includes namespaces but JSON does not. Because OpenC2 consists of multiple specifications,
-it requires a namespacing mechanism usable with JSON data.
-OpenC2 has therefore created a naming approach similar to XML's that can be applied to non-namespaced
-data formats such as JSON.  For brevity it assigns a short Namespace Identifier (NSID) to each referenced
-namespace using an **import** statement, then uses the NSID as a prefix to each referenced type:
+XML includes namespaces but JSON does not. Because OpenC2
+consists of multiple specifications, it requires a namespacing
+mechanism usable with JSON data. OpenC2 has therefore created a
+naming approach similar to XML's that can be applied to
+non-namespaced data formats such as JSON.  For brevity it assigns
+a short Namespace Identifier (NSID) to each referenced namespace
+using an **import** statement, then uses the NSID as a prefix to
+each referenced type:
 
 **schema**:
 ```
@@ -32,38 +38,55 @@ namespace using an **import** statement, then uses the NSID as a prefix to each 
     {"name": "John", "id": 12345, "email": "john@acme.com"}
 ```
 Namespacing thus involves four different values:
-* **Namespace**: The unique identifier of a referenced specification: "http://www.example.com/datatypes/v1.2"
-* **Type Name**: the name of a type defined in a referenced specification: "Email-Address"
-* **NSID**: a short abbreviation for a Namespace used as a prefix in an imported type: "ex"
-* **Field Name**: may be serialized as a JSON object property whose value is an imported type: "email"
+* **Namespace**: The unique identifier of a referenced
+  specification: "http://www.example.com/datatypes/v1.2"
+* **Type Name**: the name of a type defined in a referenced
+  specification: "Email-Address"
+* **NSID**: a short abbreviation for a Namespace used as a prefix
+  in an imported type: "ex"
+* **Field Name**: may be serialized as a JSON object property
+  whose value is an imported type: "email"
 
-NSID and Field Name are both defined by the importing specification; neither are registered here.
-Type Names (including NSID prefixes) never appear in JSON data, so Namespaces and NSIDs are never
-needed or used in JSON data except within a schema document.
+NSID and Field Name are both defined by the importing
+specification; neither are registered here. Type Names (including
+NSID prefixes) never appear in JSON data, so Namespaces and NSIDs
+are never needed or used in JSON data except within a schema
+document.
 
-This approach uses a resolver to look up all namespaced type definitions from their defining specifications
-and incorporate them into a single schema. Authors can manually copy and paste definitions
-into a monolithic specification, but namespace resolution automates that process, eliminating redundancy
-and the potential for inconsistency.
+This approach uses a resolver to look up all namespaced type
+definitions from their defining specifications and incorporate
+them into a single schema. Authors can manually copy and paste
+definitions into a monolithic specification, but namespace
+resolution automates that process, eliminating redundancy and the
+potential for inconsistency.
 
-A namespace URI is only an identifier. For syntactic reasons it must have a scheme (http) but it
-is not a network-accessible resource. 
-Referenced specifications do not need to be available online and implementations are not required to do
-namespace resolution at runtime, although dynamic namespace resolution may be appropriate for some use cases.
-URLs for online schemas should be derived from the namespace using scheme "https", filename "schema", and
-the applicable file extension: ".jadn" for the abstract schema, and ".json", ".xsd", ".cddl", ".proto", etc.
-for corresponding concrete schemas.
+A namespace URI is only an identifier. For syntactic reasons it
+must have a scheme (http) but it is not a network-accessible
+resource. Referenced specifications do not need to be available
+online and implementations are not required to do namespace
+resolution at runtime, although dynamic namespace resolution may
+be appropriate for some use cases. URLs for online schemas should
+be derived from the namespace using scheme "https", filename
+"schema", and the applicable file extension: ".jadn" for the
+abstract schema, and ".json", ".xsd", ".cddl", ".proto", etc. for
+corresponding concrete schemas.
 
 ## Registration Process
-OpenC2 TC Documentation Norms suggests
-[naming conventions](https://github.com/oasis-tcs/openc2-tc-ops/blob/master/Documentation-Norms.md#42-assign-work-product-name)
-for TC work products.  Namespace URIs should be based on this convention, omitting the filename and the "docs" domain component,
-and using "http" as the scheme component.
+OpenC2 TC Documentation Norms suggests [naming
+conventions](https://github.com/oasis-tcs/openc2-tc-ops/blob/master/Documentation-Norms.md#42-assign-work-product-name)
+for TC work products.  Namespace URIs should be based on this
+convention, omitting the filename and the "docs" domain
+component, and using "http" as the scheme component.
 
 * **Actuator Profile Name**: ap-\<function-shorthand\>
-* **Example Profile URL**: https://docs.oasis-open.org/openc2/ap-av/v1.0/ap-av-v1.0.html
+* **Example Profile URL**:
+  https://docs.oasis-open.org/openc2/ap-av/v1.0/ap-av-v1.0.html
 * **Example Namespace**: http://oasis-open.org/openc2/ap-av/v1.0
-* **Example Schema URL**: https://oasis-open.org/openc2/ap-av/v1.0/schema.jadn
+* **Example Schema URL**:
+  https://oasis-open.org/openc2/ap-av/v1.0/schema.jadn
 
-Custom actuator profile namespaces are chosen by the profile author and MUST NOT conflict with namespace URIs registered here.
-Custom profile authors MAY register Namespaces under http://oasis-open.org/openc2/custom but are not required to do so.
+Custom actuator profile namespaces are chosen by the profile
+author and MUST NOT conflict with namespace URIs registered here.
+Custom profile authors MAY register Namespaces under
+http://oasis-open.org/openc2/custom but are not required to do
+so.

--- a/oc2arch-v1.0.md
+++ b/oc2arch-v1.0.md
@@ -151,11 +151,63 @@ permitted and are defined in their respective documents.
 
 * Reformatted to December 2020 OASIS work product template
 
-## 1.2 Glossary
+## 1.2 Goal
+
+OpenC2 is developing a language for interoperating between
+functional elements of cyber defense systems. This language, used
+in conjunction with OpenC2 Actuator Profiles and OpenC2 Transfer
+Specifications, allows for vendor-agnostic cybertime response to
+attacks.
+
+The Integrated Adaptive Cyber Defense (IACD) framework defines a
+collection of activities, based on the traditional OODA
+(Observe–Orient–Decide–Act) Loop [[IACD]](#iacd):
+
+* Sensing:  gathering of data regarding system activities
+* Sense Making:  evaluating data using analytics to understand
+  what's happening
+* Decision Making:  determining a course-of-action to respond to
+  system events
+* Acting:  Executing the course-of-action
+
+The goal of OpenC2 is to enable coordinated defense in
+cyber-relevant time between decoupled blocks that perform cyber
+defense functions. OpenC2 focuses on the Acting portion of the
+IACD framework; the assumption that underlies the design of
+OpenC2 is that the sensing/analytics have been provisioned and
+the decision to act has been made. This goal and these
+assumptions guide the design of OpenC2:
+
+* **Technology Agnostic:**  The OpenC2 language defines a set of
+  abstract atomic cyber defense actions in a platform- and
+  implementation-agnostic manner
+
+* **Concise:**  A Command is intended to convey only the
+  essential information required to describe the action required
+  and can be represented in a very compact form for
+  communications-constrained environments
+
+* **Abstract:**  Commands and Responses are defined abstractly
+  and can be encoded and transferred via multiple schemes as
+  dictated by the needs of different implementation environments
+
+* **Extensible:**  While OpenC2 defines a core set of Actions and
+  Targets for cyber defense, the language is expected to evolve
+  with cyber defense technologies, and permits extensions to
+  accommodate new cyber defense technologies.
+
+The OpenC2 language assumes that the event has been detected, a
+decision to act has been made, the act is warranted, and the
+initiator and recipient of the Commands are authenticated and
+authorized. The OpenC2 language was designed to be agnostic of
+the other aspects of cyber defense implementations that realize
+these assumptions.
+
+## 1.3 Glossary
 
 <!-- Optional section with suggested subsections -->
 
-### 1.2.1 Definitions of terms
+### 1.3.1 Definitions of terms
 
 *This section is normative.*
 
@@ -193,7 +245,7 @@ permitted and are defined in their respective documents.
 -   **Target**: The object of the Action, i.e., the Action is performed on the
     Target (e.g., IP Address).
 
-### 1.2.2 Acronyms and abbreviations
+### 1.3.2 Acronyms and abbreviations
 
 | Acronym | Description |
 |---------|----------------------------------------------------------------------|
@@ -236,7 +288,7 @@ permitted and are defined in their respective documents.
 | XML     | eXtensible Markup Language |
 
 
-### 1.2.3 Document conventions
+### 1.3.3 Document conventions
 
 - Naming conventions
 - Font colors and styles


### PR DESCRIPTION
This PR adds relevant text from sections 1.7 (Goal) and 1.8 (Purpose and Scope) not currently captured in the Architecture Spec.

The addition is placed as Section 1.2; old 1.2 is renumbered to 1.3.  Old 1.3 is OASIS boilerplate on Markdown use that will be deleted so was not renumbered.

Changes to the `namespace-registry-text.md` file weren't intended to be included with this PR, but appear to only be reflow of the source text, so am leaving them there.