### PR TITLE
update AP definition in 1.3.1, matching LS

### DIFF
--- a/oc2arch-v1.0.md
+++ b/oc2arch-v1.0.md
@@ -258,7 +258,11 @@ these assumptions.
 
 -   **Actuator**: The Consumer that executes the Command.
 
--   **Actuator Profile**: The document that defines a category of operations performed by an Actuator (e.g., 'Stateless Packet Filtering').
+-   **Actuator Profile**: A defined subset of the OpenC2 language (i.e.,
+    actions, targets, command arguments, results) plus any extensions required
+    to specify the use of OpenC2 to command a particular function. Actuator
+    Profiles are defined in JADN schemas associated with published actuator
+    profile specification documents.
 
 -   **Argument**: A property of a Command that provides additional information
     on how to perform the Command, such as date/time, periodicity, duration,


### PR DESCRIPTION
This PR mirrors [LS PR 433](https://github.com/oasis-tcs/openc2-oc2ls/pull/433), and aligns the Architecture's definition of an AP with the one in the LS.

This definition should also be propagated to in-development APs.

This PR will be presented at the 24 Jan 2024 working meeting.